### PR TITLE
fix(publish): if noBump was set to true, will not try to commit to git

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -30,6 +30,7 @@ export interface publishOptions {
 	noTests: boolean;
 	naive: boolean;
 	dryRun: boolean;
+	noCommit: boolean;
 }
 
 export interface unPublishOptions {
@@ -183,6 +184,9 @@ export class PublishCommand extends BaseCommand {
 					standardArgs.skip = standardArgs.skip || {};
 					standardArgs.skip.bump = true;
 					standardArgs.skip.tag = true;
+				}
+
+				if (options.noCommit) {
 					standardArgs.skip.commit = true;
 				}
 

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -183,6 +183,7 @@ export class PublishCommand extends BaseCommand {
 					standardArgs.skip = standardArgs.skip || {};
 					standardArgs.skip.bump = true;
 					standardArgs.skip.tag = true;
+					standardArgs.skip.commit = true;
 				}
 
 				this.spinner.info('bumping version and updating changelog via standardVersion');


### PR DESCRIPTION
If you try to publish an existing library version, standard-version tries to `git commit` with a changelog fixes, and fails on it.

If noBump is set to true, we will skip the commit (and the changelog update with it).